### PR TITLE
Update 2014-12-29.md

### DIFF
--- a/posts/2014-12-29.md
+++ b/posts/2014-12-29.md
@@ -122,7 +122,7 @@ Once the computation has begun, the outer world interacts with the scope in two 
 
 The first of these two methods is relatively simple: it communicates to the scope a list of updates to timestamp counts for each of its inputs. These updates communicates progress in the outer world projected down to the scope's inputs.
 
-``rust
+```rust
 fn push_external_progress(&mut self, external: &Vec<Vec<(T, i64)>>) -> ();
 ```
 


### PR DESCRIPTION
missing '`' to display code block well formatted.