### PR TITLE
Fix a typo and some table alignment

### DIFF
--- a/posts/2017-04-24.md
+++ b/posts/2017-04-24.md
@@ -225,7 +225,7 @@ collections
 This is a total sane query, but it doesn't exploit some sweet structure we have: the keys for each of the `count` calls are themselves unsigned integers. Rather than hashing these integers all over the place (which is how we work with generic keys) we can use a special form of `count` which operates on unsigned integer keys: `count_u`. 
 
 |         |  1,000 | 10,000 | 100,000| 1,000,000 | peak rate |   hot dog |
-|--------:|-------:|-------:|-------:|----------:|----------:|----------:|
+|---------|-------:|-------:|-------:|----------:|----------:|----------:|
 | query13 |  9.18s |  5.99s |  4.79s |     3.77s | 438.03K/s | 779.52K/s |
 | query13+|  6.24s |  4.58s |  3.83s |     3.05s | 541.68K/s |           |
 
@@ -297,7 +297,7 @@ All we need to do is stitch these together by hand, removing the `as_collection(
 When we do this, we see
 
 |         |  1,000 | 10,000 | 100,000| 1,000,000 | peak rate |   hot dog |
-|--------:|-------:|-------:|-------:|----------:|----------:|----------:|
+|---------|-------:|-------:|-------:|----------:|----------:|----------:|
 | query04 | 13.34s |  7.64s |  4.46s |     2.86s |   2.62M/s |  10.08M/s |
 | query04+| 12.47s |  6.98s |  4.09s |     2.62s |   2.87M/s |           |
 
@@ -327,9 +327,9 @@ Oh hell. That `filter` lives between the count and the join. We could try moving
 Let's try it both ways and see how we do.
 
 |         |  1,000 | 10,000 | 100,000| 1,000,000 | peak rate |   hot dog |
-|--------:|-------:|-------:|-------:|----------:|----------:|----------:|
-| query04 | 38.28s | 23.57s | 16.99s |    12.04s | 637.39K/s |   1.13M/s |
-| query04+| 35.24s | 21.64s | 14.92s |    10.30s | 743.00K/s |           |
+|---------|-------:|-------:|-------:|----------:|----------:|----------:|
+| query18 | 38.28s | 23.57s | 16.99s |    12.04s | 637.39K/s |   1.13M/s |
+| query18+| 35.24s | 21.64s | 14.92s |    10.30s | 743.00K/s |           |
 
 This is definitely an improvement, and is interesting because it runs a little counter to the traditional wisdom that you should push filters as early as possible. Of course, we could wish to push the filter up, but we would need to find a way to re-use the existing index and stream of batches, which we should be able to do with a bit of friendly wrapping. There is an [issue](https://github.com/frankmcsherry/differential-dataflow/issues/36) on the differential dataflow repo to start to think about exactly this sort of thing (generalized; it also helps with time stamp manipulation, and might help with some instances of `map`).
 
@@ -375,14 +375,14 @@ revenue
 We are just doing the `max` twice, first independently on groups of 100 suppliers, and then on all of the winners of each of those contents. When one input changes, we must re-consider two inputs (for each `group`) but their sizes are each reduced by roughly 100x.
 
 |         |  1,000 | 10,000 | 100,000| 1,000,000 | peak rate |   hot dog |
-|--------:|-------:|-------:|-------:|----------:|----------:|----------:|
+|---------|-------:|-------:|-------:|----------:|----------:|----------:|
 | query15 | 35.58s | 29.46s | 31.43s |    41.29s | 204.03K/s |      17/s |
 | query15+|  2.84s |  1.32s |  0.77s |     0.85s |   7.76M/s |           |
 
 As advertised, this is almost a 50x improvement (i.e. 100x / 2). For kicks, we can do a four-level maximum where at each we reduce the key space by a factor of ten.
 
 |         |  1,000 | 10,000 | 100,000| 1,000,000 | peak rate |   hot dog |
-|--------:|-------:|-------:|-------:|----------:|----------:|----------:|
+|---------|-------:|-------:|-------:|----------:|----------:|----------:|
 | query15 | 35.58s | 29.46s | 31.43s |    41.29s | 204.03K/s |      17/s |
 | query15+|  2.84s |  1.32s |  0.77s |     0.85s |   7.76M/s |           |
 |query15++|  1.76s |  0.91s |  0.48s |     0.39s |  15.24M/s |           |


### PR DESCRIPTION
The query18 vignette had the wrong label. I also aligned the tables' first column to the left so they're easier to read / less weird ;)

From
![image](https://cloud.githubusercontent.com/assets/247183/25383062/9a8a6fc6-29ba-11e7-8656-2259d5ef75f9.png)


To
![image](https://cloud.githubusercontent.com/assets/247183/25383034/6c6b036c-29ba-11e7-99c5-0b2afaeb2e81.png)
