### PR TITLE
"test harness", not just "harness"

### DIFF
--- a/posts/2017-07-24.md
+++ b/posts/2017-07-24.md
@@ -327,7 +327,7 @@ Notice that the x-axis, throughput, goes out *lots* farther than up above. We ma
 
 ### Addendum: Open-loop measurements (2017-08-14)
 
-I was recently reading [a slide deck from Azul](https://www.youtube.com/watch?v=lJ8ydIuPFeU) which makes an excellent point, one I hadn't clearly understood: when taking latency measurements, there is a huge difference between *closed-loop* (where the harness waits for responses before making new requests) and *open-loop* (where the harness does not wait).
+I was recently reading [a slide deck from Azul](https://www.youtube.com/watch?v=lJ8ydIuPFeU) which makes an excellent point, one I hadn't clearly understood: when taking latency measurements, there is a huge difference between *closed-loop* (where the test harness waits for responses before making new requests) and *open-loop* (where the test harness does not wait).
 
 The self-regulation of a closed-loop harness can cause it to take fewer measurements in periods of poor latency.
 


### PR DESCRIPTION
At first I thought "harness" is the system under test. Which made no sense of course. This change should make it clear we are talking about testing code.