### PR TITLE
Add language specification in article's header

### DIFF
--- a/posts/2018-05-19.md
+++ b/posts/2018-05-19.md
@@ -1,4 +1,4 @@
-## A relatively simple Datalog engine
+## A relatively simple Datalog engine in Rust
 
 In this post we will build up a relatively concise [Datalog](https://en.wikipedia.org/wiki/Datalog) engine: [DataFrog](https://github.com/frankmcsherry/datafrog).
 


### PR DESCRIPTION
Hello! Thank you for the detailed thing! Funny, but I didn't knew Datalog was so old )))

My case was that I've jumped from article start right to code samples and wasn't able to get, what's the language. Proposed fix lacks elegance, but does the trick (hey, it just says "it's Rust" at the very first line).