### PR TITLE
Fix typo in scope explanation

### DIFF
--- a/posts/2014-12-29.md
+++ b/posts/2014-12-29.md
@@ -107,7 +107,7 @@ fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<S>>>,
 
 The result is simply the pair of summaries for each input to each output, and the list for each output of increments to counts for each timestamp.
 
-The second method is `set_internal_summary`, which reports back to the scope the path summaries from each of its outputs back to its inputs, as well as the initial counts for each of its inputs.
+The second method is `set_external_summary`, which reports back to the scope the path summaries from each of its outputs back to its inputs, as well as the initial counts for each of its inputs.
 
 ```rust
 fn set_external_summary(&mut self, summaries: Vec<Vec<Antichain<S>>>,


### PR DESCRIPTION
Just a small fix here I caught while taking some detailed notes from this post.