### PR TITLE
Fix broken link

### DIFF
--- a/posts/2016-05-19.md
+++ b/posts/2016-05-19.md
@@ -1,4 +1,4 @@
-Jane Bambauer and Krish Muralidhar have pushed [a blog post](http://blogs.harvard.edu/infolaw/2016/05/17/diffensive-privacy/) responding to criticisms of their "Fool's Gold" article. Their response has roughly as much technical shortfall as the Fool's Gold paper, relative to its volume, so I thought I would go through it and comment on points it makes.
+Jane Bambauer and Krish Muralidhar have pushed [a blog post](https://webcache.googleusercontent.com/search?q=cache:z-BIpjXY8YgJ:https://blogs.harvard.edu/infolaw/2016/05/17/diffensive-privacy/+&cd=1&hl=en&ct=clnk&gl=us) responding to criticisms of their "Fool's Gold" article. Their response has roughly as much technical shortfall as the Fool's Gold paper, relative to its volume, so I thought I would go through it and comment on points it makes.
 
 To keep you interested, I'm actually going to *agree* with them on one point (!!!!).
 


### PR DESCRIPTION
The link to Bambauer & Muralidhar's post doesn't seem to be working. I was able to find a cached version of the post which has some shortcomings (some images are working). Linking to a cached version is certainly a bit weird; I also wonder why Harvard took down the post.