### PR TITLE
Fix typo in code

### DIFF
--- a/posts/2019-02-09.md
+++ b/posts/2019-02-09.md
@@ -82,7 +82,7 @@ This is also a minor variation, where instead of *adding* path lengths as we go,
              .map(|(src,(dst,wid),max)|
                 (dst, ::std::cmp::min(wid, max))
              )
-             .concat(&wdith)
+             .concat(&width)
              .reduce(|key, input, output| {
                 // push maximum width (input sorted).
                 output.push((*input.last().unwrap().0, 1))


### PR DESCRIPTION
(created from mobile, not sure why GitHub.com changed last line. Whitespace? Couldn't figure out how to undo.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frankmcsherry/blog/41)
<!-- Reviewable:end -->
